### PR TITLE
Separate history & watchlist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Name: betaseries-to-trakt
 Redirect uri: urn:ietf:wg:oauth:2.0:oob
 ```
 
-You don't really care about the others fields.
+You don't really care about the other fields.
 
 Next, go to [your api applications](https://trakt.tv/oauth/applications) and click on the one named `betaseries-to-trakt`
 
 You will need the `Client ID` and the `Client Secret` from that page.
 
-### The script
+### Running the script
 
 #### With Docker
 ```
@@ -51,6 +51,45 @@ CLIENT_ID=theclientID CLIENT_SECRET=theclientseccret python3 betaseries-to-trakt
 Follow the script instructions
 
 ET VOILA!
+
+## What does the script do ?
+
+### TV Shows
+
+- shows with no episodes watched will be added to your Trakt's Shows watchlist
+
+```
+// example
+
+id,thetvdb_id,title,archive,episode,remaining,status,tags
+3764,250487,"American Horror Story",1,S00E00,84,0,
+```
+
+- shows that have at least 1 episode seen will be added to your Trakt's history (the seen episodes `watched at` dates will be set to the release date, as Betaseries does not provide this information in the CSV export)
+
+```
+// example
+
+id,thetvdb_id,title,archive,episode,remaining,status,tags
+4189,253463,"Black Mirror",0,S02E03,13,"31,58",
+```
+
+### Movies
+
+There are 3 different statuses for a movie in Betaseries
+
+- Movies with the status `0` (= `je veux voir`) will be added to your Trakt's Movies watchlist
+- Movies with the status `1` (= `j'ai vu`) will be added to your Trakt's Movies history (the `watched at` date will be set to the release date, as Betaseries does not provide this information in the CSV export)
+- Movies with the status `2` (= `je ne veux pas voir`) will be ignored
+
+```
+// example
+
+id,tmdb_id,title,status
+193,19995,Avatar,1
+13157,76757,"Jupiter : Le Destin de l'univers",2
+92,49051,"Le Hobbit : Un voyage inattendu",0
+```
 
 ## License
 


### PR DESCRIPTION
This fixes the issues that were raised in https://github.com/tuxity/betaseries-to-trakt/issues/4

- adds `/sync/watchlist` api call
- empty shows (`S00E00`) are now pushed to trakt watchlist instead of 100% watched
- improve movies management (seperate watched and watchlist)
- update console summary print
- tested with multiple scenarios :)

the script's run command doesn't change

<hr>

Trakt API links:
- /sync/history : https://trakt.docs.apiary.io/#reference/sync/add-to-history/add-items-to-watched-history
- /sync/watchlist : https://trakt.docs.apiary.io/#reference/sync/add-to-watchlist/add-items-to-watchlist